### PR TITLE
fix redundant root directory creation

### DIFF
--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -44,8 +44,14 @@ func main() {
 			}
 
 			mountPoint := fmt.Sprintf("%s/store", flags.Args.RootDir)
-			if err := os.MkdirAll(mountPoint, 0755); err != nil {
-				return errors.Wrap(err, "mkdir dir store failed")
+			if _, err := os.Stat(mountPoint); err != nil {
+				if os.IsNotExist(err) {
+					if err := os.MkdirAll(mountPoint, 0755); err != nil {
+						return errors.Wrapf(err, "create root directory %s", mountPoint)
+					}
+				} else {
+					return errors.Wrapf(err, "stat root directory %s", mountPoint)
+				}
 			}
 
 			// replace it with nydus-snapshotter resolver.


### PR DESCRIPTION
We only need to create `/var/lib/nydus-store/store` if not exists,
otherwise an error will be thrown:

```
mkdir dir store failed: mkdir /var/lib/nydus-store/store: file exists
```

Because `/var/lib/nydus-store/store` may be a mountpoint leaked
by last mount operation.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>