### PR TITLE
refactor: make nydus storage plugin work stable.

### DIFF
--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -65,6 +65,7 @@ func main() {
 				log.G(c.Context).WithError(err).Fatalf("failed to mount fs at %q", mountPoint)
 			}
 			defer func() {
+				layManager.ReleaseAll(c.Context)
 				err := syscall.Unmount(mountPoint, 0)
 				if err != nil {
 					log.G(c.Context).Error(err)

--- a/pkg/fs/ref_node.go
+++ b/pkg/fs/ref_node.go
@@ -66,7 +66,7 @@ func (n *refNode) Rmdir(ctx context.Context, name string) syscall.Errno {
 		log.G(ctx).WithError(err).Warnf("invalid digest for %q during release", name)
 		return syscall.EINVAL
 	}
-	current, err := n.fs.layManager.Release(ctx, n.ref, targetDigest)
+	current, err := n.fs.layManager.Release(ctx, n.ref, targetDigest, n.rawRef)
 	if err != nil {
 		log.G(ctx).WithError(err).Warnf("failed to release layer %v / %v", n.ref, targetDigest)
 		return syscall.EIO


### PR DESCRIPTION
fix: https://github.com/containers/nydus-storage-plugin/issues/4

Using nydus fs wait for ready method to let storage bind diff director correctly.

fix: https://github.com/containers/nydus-storage-plugin/issues/3

At exit release all mount bind